### PR TITLE
fixes issue with the latest version of Übersicht

### DIFF
--- a/hddspace.widget/index.coffee
+++ b/hddspace.widget/index.coffee
@@ -43,26 +43,26 @@ update: (output, domEl) ->
   $(domEl).find('.system-val').html(output)
 
 style: """
-	top: #{@style.position.top}
-	bottom: #{@style.position.bottom}
-	right: #{@style.position.right}
-	left: #{@style.position.left}
-	width: #{@style.width}
-	font-family: #{@style.font}
-	color: #{@style.font_color}
-	font-weight: #{@style.font_weight}
-	text-align: #{@style.text_align}
-	text-transform: #{@style.text_transform}
-	font-size: #{@style.font_size}
-	letter-spacing: #{@style.letter_spacing}
+	top: #{style.position.top}
+	bottom: #{style.position.bottom}
+	right: #{style.position.right}
+	left: #{style.position.left}
+	width: #{style.width}
+	font-family: #{style.font}
+	color: #{style.font_color}
+	font-weight: #{style.font_weight}
+	text-align: #{style.text_align}
+	text-transform: #{style.text_transform}
+	font-size: #{style.font_size}
+	letter-spacing: #{style.letter_spacing}
 	font-smoothing: antialiased
-	text-shadow: #{@style.shadow.x_offset} #{@style.shadow.y_offset} #{@style.shadow.blur} #{@style.shadow.color}
-	line-height: #{@style.line_height}
+	text-shadow: #{style.shadow.x_offset} #{style.shadow.y_offset} #{style.shadow.blur} #{style.shadow.color}
+	line-height: #{style.line_height}
 
 	.icon
-		background: url('#{@style.icon.png}')
-		-webkit-filter: drop-shadow(#{@style.shadow.x_offset} #{@style.shadow.y_offset} #{@style.shadow.blur} #{@style.shadow.color})
-		filter: drop-shadow(#{@style.shadow.x_offset} #{@style.shadow.y_offset} #{@style.shadow.blur} #{@style.shadow.color})
+		background: url('#{style.icon.png}')
+		-webkit-filter: drop-shadow(#{style.shadow.x_offset} #{style.shadow.y_offset} #{style.shadow.blur} #{style.shadow.color})
+		filter: drop-shadow(#{style.shadow.x_offset} #{style.shadow.y_offset} #{style.shadow.blur} #{style.shadow.color})
 
 	.bg
     height: 40px


### PR DESCRIPTION
previous versions accidentally allowed some invalid CoffeScript syntax. The latest version 'fixes' that, but it causes some widgets to break. Lucky the fix is simple
